### PR TITLE
Add readme version test

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The package can be installed by adding `unicode` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:unicode, "~> 1.18.1"}
+    {:unicode, "~> 1.18"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Elixir standard library does not provide introspection beyond that required 
 
 ### Unicode version
 
-As of [unicode version 1.17.0](https://hex.pm/pacakges/unicode/1.17.0) published on September 17th, 2023, [Unicode 15.1](https://www.unicode.org/versions/Unicode15.1.0/) forms the underlying data.
+As of [unicode version 1.17.0](https://hex.pm/packages/unicode/1.17.0) published on September 17th, 2023, [Unicode 15.1](https://www.unicode.org/versions/Unicode15.1.0/) forms the underlying data.
 
 ## Additional Unicode libraries
 
@@ -183,12 +183,14 @@ The information functions are heavily inspired by [@qqwy's elixir-unicode packag
 
 The package can be installed by adding `unicode` to your list of dependencies in `mix.exs`:
 
+<!-- BEGIN: VERSION -->
 ```elixir
 def deps do
   [
-    {:unicode, "~> 1.15"}
+    {:unicode, "~> 1.18.1"}
   ]
 end
 ```
+<!-- END: VERSION -->
 
 The docs can be found at [https://hexdocs.pm/unicode](https://hexdocs.pm/unicode).

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Unicode.MixProject do
   use Mix.Project
 
-  @version "1.18.0-dev"
+  @version "1.18.1"
 
   def project do
     [

--- a/test/readme_test.exs
+++ b/test/readme_test.exs
@@ -1,0 +1,15 @@
+defmodule ReadmeTest do
+  use ExUnit.Case, async: true
+
+  test "readme version matches mix" do
+    [_, readme_version_text, _] =
+      Path.join(__DIR__, "../README.md")
+      |> File.read!()
+      |> String.split(["<!-- BEGIN: VERSION -->", "<!-- END: VERSION -->"])
+
+    [readme_version] = Regex.run(~r/{:unicode, \"~> (?<version>.*)\"}/, readme_version_text, capture: :all_names)
+
+    mix_version = Mix.Project.config()[:version]
+    assert readme_version === mix_version
+  end
+end

--- a/test/readme_test.exs
+++ b/test/readme_test.exs
@@ -7,9 +7,15 @@ defmodule ReadmeTest do
       |> File.read!()
       |> String.split(["<!-- BEGIN: VERSION -->", "<!-- END: VERSION -->"])
 
-    [readme_version] = Regex.run(~r/{:unicode, \"~> (?<version>.*)\"}/, readme_version_text, capture: :all_names)
+    [readme_version] = Regex.run(~r/{:unicode, \"(?<version>.*)\"}/, readme_version_text, capture: :all_names)
+    {:ok, readme_version} = Version.parse_requirement(readme_version)
+    [:~>, {readme_major, readme_minor, _, _, _}] = readme_version.lexed()
 
-    mix_version = Mix.Project.config()[:version]
-    assert readme_version === mix_version
+    %Version{major: mix_major, minor: mix_minor} =
+      Mix.Project.config()[:version]
+      |> Version.parse!()
+
+    assert mix_major === readme_major
+    assert mix_minor === readme_minor
   end
 end


### PR DESCRIPTION
This test ensures the text in `README.md` always reflects the version specified in `mix.exs`.

`String.split/3` is used along with comment tags to disambiguate what part of the readme is checked.

`Regex.run/3` is used to match the version, which makes for a nicer error message than `~=`.